### PR TITLE
feat(docker): tested docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,16 +157,11 @@ In the same directory, subdirectories _naughty_carson_2_, _goofy_hypatia_2_, and
 
 ## Run AMBER as a Biobox
 
-1. Build the container running the following command:
+
+Run the amber docker image by specifying the executing the following command
 
 ~~~BASH
-docker build  -t amber .
-~~~
-
-2. Run the container by specifying the executing the following command
-
-~~~BASH
-docker run -v $(pwd)/input/gold_standard.fasta:/bbx/input/gold_standard.fasta -v $(pwd)/input/gsa_mapping.binning:/bbx/input/gsa_mapping.binning  -v  $(pwd)/input/test_query.binning:/bbx/input/test_query.binning  -v  $(pwd)/output:/bbx/output -v $(pwd)/input/biobox.yaml:/bbx/input/biobox.yaml amber default
+docker run -v $(pwd)/input/gold_standard.fasta:/bbx/input/gold_standard.fasta -v $(pwd)/input/gsa_mapping.binning:/bbx/input/gsa_mapping.binning  -v  $(pwd)/input/test_query.binning:/bbx/input/test_query.binning  -v  $(pwd)/output:/bbx/output -v $(pwd)/input/biobox.yaml:/bbx/input/biobox.yaml cami/amber:latest default
 ~~~
 
 where biobox.yaml contains the following values:
@@ -187,7 +182,7 @@ arguments:
 
 # Developer Guide
 
-We are using [tox]((https://tox.readthedocs.io/en/latest/)) for project automation.
+We are using [tox](https://tox.readthedocs.io/en/latest/) for project automation.
 
 ### Tests
 
@@ -195,4 +190,10 @@ If you want to run tests, just type _tox_ in the project's root directory:
 
 ~~~BASH
 tox
+~~~  
+
+By running tox you can use all libraries that amber depends on by running 
+
+~~~BASH
+source  <project_directory>/.tox/py35/bin/activate
 ~~~

--- a/circle.yml
+++ b/circle.yml
@@ -14,3 +14,4 @@ dependencies:
 test:
   override:
     - tox
+    - docker build --rm=false -t test_amber .

--- a/image/bin/install.sh
+++ b/image/bin/install.sh
@@ -1,0 +1,18 @@
+FROM bioboxes/biobox-minimal-base
+
+apt update
+apt-get install -y wget libssl-dev openssl build-essential 
+
+# install python3
+wget https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tgz 
+tar xzvf Python-3.5.0.tgz && cd Python-3.5.0 
+./configure 
+make
+make install
+ln -s /usr/local/bin/python3 /usr/local/bin/python 
+
+# install pip
+apt install -y python3-pip python3-dev pkg-config libfreetype6-dev 
+
+# remove make, configure and wget
+apt remove -y build-essential wget


### PR DESCRIPTION
This PR solves #12  . I registered amber on DockerHub. Every release made in amber will trigger a build on Dockerhub. Which means that if we create a release with number 0.5.0 a user can run

~~~BASH
docker pull cami/amber:0.5.0
~~~

in order to get the corresponding image version.