### PR TITLE
Add citation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,11 @@ or a specific tag
 ~~~BASH
 pip3 install https://github.com/CAMI-challenge/AMBER/archive/tag.tar.gz 
 ~~~
+
+# Citation
+
+A manuscript describing AMBER is currently under review, but its preprint version is available already:
+* Meyer et al. (2017). **AMBER: Assessment of Metagenome BinnERs.** *bioRxiv*, 239582. doi:[10.1101/239582](https://doi.org/10.1101/239582)
+
+The metrics implemented in AMBER were used and described in the CAMI manuscript, thus you may also cite:
+* Sczyrba*, Hofmann*, Belmann*, et al. (2017). **Critical Assessment of Metagenome Interpretation—a benchmark of metagenomics software.** *Nature Methods*, 14, 11:1063–1071. doi:[10.1038/nmeth.4458](https://doi.org/10.1038/nmeth.4458)


### PR DESCRIPTION
AMBER is open source and thus available to the public, but a citation info was lacking. I added two suggestions to your README: (1) the AMBER preprint and (2) the CAMI flagship paper.

From my point of view, both would be fine to cite as is. Some journals still don't allow preprints to be cited, that's why I included the CAMI flagship paper – at least for now. Fingers crossed!